### PR TITLE
Feature/debug logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         model: [bart, pegasus, t5]
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-ubuntu-2204-arm]
     uses: taranis-ai/github-actions/.github/workflows/build-multiarch-bot-container.yml@master
     with:
       ghcr_image: ghcr.io/taranis-ai/taranis-summarize-bot

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Run via
 ```bash
 flask run
 # or
-granian run
+granian app
 # or
 docker run -p 8000:8000 ghcr.io/taranis-ai/taranis-summarize-bot:latest
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"
+tag_regex = "^refs/pull/(\\d+)/merge$"
 
 [tool.setuptools]
 packages = ["summarize_bot"]

--- a/summarize_bot/decorators.py
+++ b/summarize_bot/decorators.py
@@ -5,6 +5,17 @@ from summarize_bot.config import Config
 from summarize_bot.log import logger
 
 
+def debug_request(func):
+    def wrapper(*args, **kwargs):
+        log_str = f"Method: {request.method}, Endpoint: {request.path}, "
+        payload = request.get_json(silent=True)
+        if payload is not None:
+            log_str += f"Payload: {payload}"
+        logger.debug(log_str)
+        return func(*args, **kwargs)
+    return wrapper
+
+
 def api_key_required(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):

--- a/summarize_bot/router.py
+++ b/summarize_bot/router.py
@@ -4,6 +4,7 @@ from flask.views import MethodView
 from summarize_bot.predictor_factory import PredictorFactory
 from summarize_bot.predictor import Predictor
 from summarize_bot.decorators import api_key_required
+from summarize_bot.decorators import debug_request
 
 
 class SummarizeText(MethodView):
@@ -11,6 +12,7 @@ class SummarizeText(MethodView):
         super().__init__()
         self.processor = processor
 
+    @debug_request
     @api_key_required
     def post(self):
         data = request.get_json()
@@ -20,6 +22,7 @@ class SummarizeText(MethodView):
 
 
 class HealthCheck(MethodView):
+    @debug_request
     def get(self):
         return jsonify({"status": "ok"})
 
@@ -28,7 +31,7 @@ class ModelInfo(MethodView):
     def __init__(self, processor: Predictor):
         super().__init__()
         self.processor = processor
-
+    @debug_request
     def get(self):
         return jsonify(self.processor.modelinfo)
 


### PR DESCRIPTION
Add a debug decorator that logs the request type, endpoint and payload (for POST requests) when DEBUG=True.
This is needed since the Granian app does not log requests by default as Flask does.

Switch to blacksmith.sh runners