### PR TITLE
Allow structured News Item input

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,29 @@
 from summarize_bot.config import Config
 from taranis_base_bot import create_app
+from taranis_base_bot.log import logger
+from typing import Any
 
-app = create_app(Config.PACKAGE_NAME, Config)
+def request_parser(data: dict) -> dict[str, Any]:
+    if unexpected_keys := set(data) - set(Config.PAYLOAD_SCHEMA):
+        logger.warning(f"The payload contains unexpected keys: {unexpected_keys}")
+
+    accepted_data = {}
+    for key, key_schema in Config.PAYLOAD_SCHEMA.items():
+        if not key_schema.get("required", True) and key not in data:
+            continue
+
+        if key not in data:
+            raise ValueError(f"Payload does not contain '{key}' key!")
+
+        val = data.get(key)
+        if val is None or (isinstance(val, (tuple, list, str)) and not val):
+            raise ValueError(f"No data provided for '{key}' key!")
+
+        data_type = key_schema.get("type")
+
+        if data_type and not isinstance(val, (list, str)): 
+            raise ValueError(f"Data for '{key}' is not of type '{data_type}'")
+        accepted_data[key] = data[key]
+    return accepted_data
+
+app = create_app(Config.PACKAGE_NAME, Config, request_parser=request_parser)

--- a/summarize_bot/bart.py
+++ b/summarize_bot/bart.py
@@ -1,6 +1,7 @@
 from transformers import pipeline
 from summarize_bot.config import Config
-
+from typing import Any
+from summarize_bot.utils import build_story_input_text
 
 class Bart:
     model_name = "facebook/bart-large-cnn"
@@ -8,15 +9,19 @@ class Bart:
     def __init__(self):
         self.summarizer = pipeline("summarization", model=self.model_name)
 
-    async def predict(self, text: str) -> dict[str, str]:
-        if not text:
-            raise ValueError("No text to summarize.")
+    async def predict(self, news_items: list[dict[str, Any]] | None = None, text: str | None = None) -> dict[str, str]:
+        if news_items:
+            text_to_summarize = build_story_input_text(news_items)
+        elif text:
+            text_to_summarize = text
+        else:
+            raise ValueError("No input to summarize")
 
-        if len(text) < Config.MAX_LEN:
-            return {"summary": text}
+        if len(text_to_summarize) < Config.MAX_LEN:
+            return {"summary": text_to_summarize}
 
         summary = self.summarizer(
-            text,
+            text_to_summarize,
             max_new_tokens=Config.MAX_LEN,
             num_beams=Config.NUM_BEAMS,
             min_length=Config.MIN_LEN,

--- a/summarize_bot/config.py
+++ b/summarize_bot/config.py
@@ -6,7 +6,7 @@ class Settings(CommonSettings):
     MODEL: Literal["t5", "bart", "pegasus"] = "t5"
     PACKAGE_NAME: str = "summarize_bot"
     HF_MODEL_INFO: bool = True
-    PAYLOAD_SCHEMA: dict[str, dict] = {"text": {"type": "str", "required": True}}
+    PAYLOAD_SCHEMA: dict[str, dict] = {"news_items": {"type": list, "required": False}, "text":  {"type": dict, "required": False}}
     MAX_LEN: int = 280
     MIN_LEN: int = 80
     NUM_BEAMS: int = 4

--- a/summarize_bot/pegasus.py
+++ b/summarize_bot/pegasus.py
@@ -1,6 +1,7 @@
 from transformers import PegasusTokenizer, PegasusForConditionalGeneration
 from summarize_bot.config import Config
-
+from typing import Any
+from summarize_bot.utils import build_story_input_text
 
 class Pegasus:
     model_name = "google/pegasus-xsum"
@@ -9,14 +10,18 @@ class Pegasus:
         self.tokenizer = PegasusTokenizer.from_pretrained(self.model_name)
         self.summarizer = PegasusForConditionalGeneration.from_pretrained(self.model_name)
 
-    async def predict(self, text: str) -> dict[str, str]:
-        if not text:
-            raise ValueError("No text to summarize.")
+    async def predict(self, news_items: list[dict[str, Any]] | None = None, text: str | None = None) -> dict[str, str]:
+        if news_items:
+            text_to_summarize = build_story_input_text(news_items)
+        elif text:
+            text_to_summarize = text
+        else:
+            raise ValueError("No input to summarize")
 
-        if len(text) < Config.MAX_LEN:
-            return {"summary": text}
+        if len(text_to_summarize) < Config.MAX_LEN:
+            return {"summary": text_to_summarize}
 
-        inputs = self.tokenizer(text, truncation=True, padding="longest", return_tensors="pt")
+        inputs = self.tokenizer(text_to_summarize, truncation=True, padding="longest", return_tensors="pt")
         summary_ids = self.summarizer.generate(
             inputs.input_ids,
             max_new_tokens=Config.MAX_LEN,

--- a/summarize_bot/t5.py
+++ b/summarize_bot/t5.py
@@ -1,5 +1,7 @@
 from transformers import pipeline, T5Tokenizer
 from summarize_bot.config import Config
+from typing import Any
+from summarize_bot.utils import build_story_input_text
 
 
 class T5:
@@ -9,15 +11,19 @@ class T5:
         tokenizer = T5Tokenizer.from_pretrained(self.model_name, legacy=True)
         self.summarizer = pipeline("summarization", model=self.model_name, tokenizer=tokenizer)
 
-    async def predict(self, text: str) -> dict[str, str]:
-        if not text:
-            raise ValueError("No text to summarize.")
+    async def predict(self, news_items: list[dict[str, Any]] | None = None, text: str | None = None) -> dict[str, str]:
+        if news_items:
+            text_to_summarize = build_story_input_text(news_items)
+        elif text:
+            text_to_summarize = text
+        else:
+            raise ValueError("No input to summarize")
 
-        if len(text) < Config.MAX_LEN:
-            return {"summary": text}
+        if len(text_to_summarize) < Config.MAX_LEN:
+            return {"summary": text_to_summarize}
 
         summary = self.summarizer(
-            text,
+            text_to_summarize,
             max_new_tokens=Config.MAX_LEN,
             num_beams=Config.NUM_BEAMS,
             min_length=Config.MIN_LEN,

--- a/summarize_bot/utils.py
+++ b/summarize_bot/utils.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+def build_story_input_text(news_items: list[dict[str, Any]]) -> str:
+    formatted_items = []
+    formatted_items.extend(
+        "\n".join(
+            [
+                f"News item {index}",
+                f"Title: {news_item.get("title", "")}",
+                "Content:",
+                news_item.get("content", "-"),
+            ]
+        )
+        for index, news_item in enumerate(news_items, start=1)
+    )
+    return "\n\n".join(formatted_items)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,3 +169,11 @@ def content7():
 @pytest.fixture(params=["content1", "content2", "content3", "content4", "content5", "content6", "content7"])
 def article(request):
     return request.getfixturevalue(request.param)
+
+
+@pytest.fixture()
+def structured_input():
+    return [
+            {"title": "First title", "content": "First content"},
+            {"title": "Second title", "content": "Second content"},
+        ]

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -6,7 +6,7 @@ from summarize_bot.config import Config
 
 async def test_summarize_bart(article: tuple[str, list], bart_model: Bart):
     content, expected = article
-    result = await bart_model.predict(content)
+    result = await bart_model.predict(text=content)
     assert isinstance(result, dict)
     assert set(result) == {"summary"}
     assert isinstance(result["summary"], str)
@@ -14,10 +14,13 @@ async def test_summarize_bart(article: tuple[str, list], bart_model: Bart):
     assert len(result["summary"]) < Config.MAX_LEN * 2.5, f"Summary exceeds maximum length.: {len(result['summary'])} > {Config.MAX_LEN}"
     assert len(result["summary"]) > Config.MIN_LEN, f"Summary is shorter than minimum length.: {len(result['summary'])} < {Config.MIN_LEN}"
 
+async def test_summarize_bart_with_structured_input(structured_input: list[dict], bart_model: Bart):
+    result = await bart_model.predict(news_items=structured_input)
+    assert isinstance(result, dict)
 
 async def test_summarize_pegasus(article: tuple[str, list], pegasus_model: Pegasus):
     content, expected = article
-    result = await pegasus_model.predict(content)
+    result = await pegasus_model.predict(text=content)
     assert isinstance(result, dict)
     assert set(result) == {"summary"}
     assert isinstance(result["summary"], str)
@@ -25,12 +28,20 @@ async def test_summarize_pegasus(article: tuple[str, list], pegasus_model: Pegas
     assert len(result["summary"]) < Config.MAX_LEN * 2.5, f"Summary exceeds maximum length.: {len(result['summary'])} > {Config.MAX_LEN}"
     assert len(result["summary"]) > Config.MIN_LEN, f"Summary is shorter than minimum length.: {len(result['summary'])} < {Config.MIN_LEN}"
 
+async def test_summarize_pegasus_with_structured_input(structured_input: list[dict], pegasus_model: Pegasus):
+    result = await pegasus_model.predict(news_items=structured_input)
+    assert isinstance(result, dict)
+
 async def test_summarize_t5(article: tuple[str, list], t5_model: T5):
     content, expected = article
-    result = await t5_model.predict(content)
+    result = await t5_model.predict(text=content)
     assert isinstance(result, dict)
     assert set(result) == {"summary"}
     assert isinstance(result["summary"], str)
     assert sum(word in result["summary"] for word in expected) >= 1, f"No expected keywords were found in the summary: {result}"
     assert len(result["summary"]) < Config.MAX_LEN * 2.5, f"Summary exceeds maximum length.: {len(result['summary'])} > {Config.MAX_LEN}"
     assert len(result["summary"]) > Config.MIN_LEN, f"Summary is shorter than minimum length.: {len(result['summary'])} < {Config.MIN_LEN}"
+
+async def test_summarize_t5_with_structured_input(structured_input: list[dict], t5_model: T5):
+    result = await t5_model.predict(news_items=structured_input)
+    assert isinstance(result, dict)


### PR DESCRIPTION
Allow the summarize_bot to use News Item Lists ([{"title": <str>, "content": <str>}, ...]) as input in addition to text